### PR TITLE
Only the current window object should receive notifications

### DIFF
--- a/basic-opengl-swift/OpenGLView.swift
+++ b/basic-opengl-swift/OpenGLView.swift
@@ -39,7 +39,7 @@ class OpenGLView: NSOpenGLView
         /* BUG: When exiting a fullscreen view windowClosing() will be called. */
         NotificationCenter.default.addObserver( self, selector: #selector( OpenGLView.windowClosing ),
                                                           name: NSNotification.Name.NSWindowWillClose,
-                                                        object: nil )
+                                                        object: self.window )
     }
     
     


### PR DESCRIPTION
If the notification object is nil all open windows will receive the NSWindowWillClose notification.